### PR TITLE
Corrected installation script in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ __NOTE__: You do not need to fork this repo to install/use the liberator tool.
 Run the following (you'll be prompted for you github username and password):
 
   ```sh
-  npm install -g git+https://github.com/hackreactor/liberator.git
+  npm install -g git+https://github.com/hackreactor-labs/hackreactor.git
   ```
 
 ## Configuration


### PR DESCRIPTION
The installation script in README.md gave an error that the repo was not found.

<img width="682" alt="screen shot 2016-01-18 at 8 05 00 am" src="https://cloud.githubusercontent.com/assets/15370822/12394700/bda8b21e-bdba-11e5-8e8d-4809556e9352.png">

Corrected the script to point to the correct location for liberator.

<img width="682" alt="screen shot 2016-01-18 at 8 05 25 am" src="https://cloud.githubusercontent.com/assets/15370822/12394705/c48ae08e-bdba-11e5-8602-9727cffe1771.png">
